### PR TITLE
Fix test execution errors and some typos

### DIFF
--- a/lib/LinuxLab_HRT_Lib.py
+++ b/lib/LinuxLab_HRT_Lib.py
@@ -279,7 +279,7 @@ class LinuxLab_HRT_Lib:
         chk = tuple(p.split(check_val))
 
         if (len(ret_val) != len(chk)):
-            msg = ("invalid number of values: return values %d, expexted %d" %(len(ret_val), len(chk)))
+            msg = ("invalid number of values: return values %d, expected %d" %(len(ret_val), len(chk)))
             raise AssertionError(msg)
 
         if (self._log):
@@ -336,7 +336,7 @@ class LinuxLab_HRT_Lib:
             print("*INFO:* current value: '%s'" % (response))
 
         if (response != val):
-            msg = ("invalid value '%s', expexted '%s'" %(response, val))
+            msg = ("invalid value '%s', expected '%s'" %(response, val))
             raise AssertionError(msg)
 
     # run 'systemctl show --property <param>'
@@ -369,7 +369,7 @@ class LinuxLab_HRT_Lib:
         chk = tuple(p.split(check_val))
 
         if (len(ret_val) != len(chk)):
-            msg = ("invalid number of values: return values %d, expexted %d" %(len(ret_val), len(chk)))
+            msg = ("invalid number of values: return values %d, expected %d" %(len(ret_val), len(chk)))
             raise AssertionError(msg)
 
         rc = 0
@@ -405,7 +405,7 @@ class LinuxLab_HRT_Lib:
 
         response = self._systemctl_show_get_param(param)
         if (response != val):
-            msg = ("invalid value '%s', expexted '%s'" %(response, val))
+            msg = ("invalid value '%s', expected '%s'" %(response, val))
             raise AssertionError(msg)
 
     # run 'systemctl show --property <param>'
@@ -434,7 +434,7 @@ class LinuxLab_HRT_Lib:
             if (self._verbose):
                 print("match: '%s' >>>%s<<<\n" %(pattern, response))
         else:
-            msg = ("invalid value '%s', expexted regex '%s'" %(response, pattern))
+            msg = ("invalid value '%s', expected regex '%s'" %(response, pattern))
             raise AssertionError(msg)
 
     # run <cmd> <param>'
@@ -485,7 +485,7 @@ class LinuxLab_HRT_Lib:
         chk = tuple(p.split(check_val))
 
         if (len(ret_val) != len(chk)):
-            msg = ("invalid number of values: return values %d, expexted %d" %(len(ret_val), len(chk)))
+            msg = ("invalid number of values: return values %d, expected %d" %(len(ret_val), len(chk)))
             raise AssertionError(msg)
 
         rc = 0
@@ -529,7 +529,7 @@ class LinuxLab_HRT_Lib:
         response = self._run_cmd_skip(l, skip_str)
 
         if (response != val):
-            msg = ("invalid value '%s', expexted '%s'" %(response, val))
+            msg = ("invalid value '%s', expected '%s'" %(response, val))
             raise AssertionError(msg)
 
     def run_cmd_str(self, cmd, val):
@@ -566,7 +566,7 @@ class LinuxLab_HRT_Lib:
         response = self._run_cmd(cmd)
 
         if (response != check_val):
-            msg = ("invalid value '%s', expexted '%s'" %(response, check_val))
+            msg = ("invalid value '%s', expected '%s'" %(response, check_val))
             if (self._verbose):
                 print(msg)
             raise AssertionError(msg)
@@ -587,7 +587,7 @@ class LinuxLab_HRT_Lib:
         response = self._run_cmd(cmd)
 
         if (response != check_val):
-            msg = ("invalid value '%s', expexted '%s'" %(response, check_val))
+            msg = ("invalid value '%s', expected '%s'" %(response, check_val))
             if (self._verbose):
                 print(msg)
             raise AssertionError(msg)

--- a/tests/sles-15-SP6/sysctl.robot
+++ b/tests/sles-15-SP6/sysctl.robot
@@ -62,7 +62,6 @@ Sysctl_user_max_time_namespaces
 Sysctl_user_max_user_namespaces
     [Documentation]    Depends of the RAM resources bsc#1183339#c11 bsc#1202375#c1
     Sysctl Check Param Int    user.max_user_namespaces    7700:7800
-    [Documentation]    Depends of the RAM resources bsc#1183339#c11
 Sysctl_user_max_uts_namespaces
     [Documentation]    Depends of the RAM resources bsc#1183339#c11 bsc#1202375#c1
     Sysctl Check Param Int    user.max_uts_namespaces    7700:7800
@@ -389,8 +388,6 @@ Sysctl_kernel_max_rcu_stall_to_panic
     Sysctl Check Param Int    kernel.max_rcu_stall_to_panic    0
 Sysctl_kernel_oops_all_cpu_backtrace
     Sysctl Check Param Int    kernel.oops_all_cpu_backtrace    0
-Sysctl_kernel_sched_deadline_period_max_us
-    Sysctl Check Param Int    kernel.sched_deadline_period_max_us    4194304
 Sysctl_kernel_sched_deadline_period_max_us
     Sysctl Check Param Int    kernel.sched_deadline_period_max_us    4194304
 Sysctl_kernel_sched_deadline_period_min_us


### PR DESCRIPTION
Fix the Test Execution Error below:
Error in file '/robot/tests/sles-15-SP6/sysctl.robot' on line 65: Setting 'Documentation' is allowed only once. Only the first value is used.

Multiple test cases with name 'Sysctl_kernel_sched_deadline_period_max_us' executed in test suite 'Sysctl'.